### PR TITLE
Removed the id from uri path and added a Page Error component

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,17 +1,20 @@
 import React, { Component } from 'react'
 import Landing from './components/Landing/Landing'
 import RocketList from './components/RocketList/RocketList'
-import { Route, Redirect, withRouter } from 'react-router-dom'
+import PageError from './components/PageError/PageError'
+import { Route, Switch, Redirect, withRouter } from 'react-router-dom'
 import './App.css'
 
 class App extends Component {
   render () {
     return (
       <div className='app'>
-        {!localStorage.getItem('token') && !localStorage.getItem('id') ? <Route exact path='/' component={Landing} /> : null }
-        {localStorage.getItem('token') && localStorage.getItem('id') ? <Route exact path='/:userId' component={Landing} /> : null}
-        {localStorage.getItem('token') && localStorage.getItem('id') ? <Route exact path='/:userId/:choice' component={RocketList} /> : null}
-        {localStorage.getItem('token') && localStorage.getItem('id') && window.location.pathname === '/' ? <Redirect to={`/${localStorage.getItem('id')}`} /> : null}
+        <Switch>
+          <Route exact path='/' component={Landing} />
+          {localStorage.getItem('token') ? <Route exact path='/rocket/:page' component={RocketList} /> : null}
+          {localStorage.getItem('token') && (window.location.pathname === '/rocket' || window.location.pathname === '/rocket/') ? <Redirect to='/rocket/quizzes' /> : null}
+          <Route component={PageError} />
+        </Switch>
       </div>
     )
   }

--- a/client/src/components/Landing/FirstSection.js
+++ b/client/src/components/Landing/FirstSection.js
@@ -14,7 +14,7 @@ class FirstSection extends Component {
   }
 
   toggleGetStarted = () => {
-    if (localStorage.getItem('token') && localStorage.getItem('id')) {
+    if (localStorage.getItem('token')) {
       this.setState({
         redirect: true
       })

--- a/client/src/components/Modals/LogInModal.js
+++ b/client/src/components/Modals/LogInModal.js
@@ -51,7 +51,6 @@ class LogInModal extends Component {
                   const logInData = data.data.queryTeacher
                   if (logInData) {
                     localStorage.setItem('token', logInData.jwtString)
-                    localStorage.setItem('id', logInData.teacher.TeacherID)
                     this.setState({
                       email: '',
                       password: '',
@@ -91,7 +90,7 @@ class LogInModal extends Component {
             </div>
           )}
         </Mutation>
-        {this.state.redirect ? <Redirect to={`/${localStorage.getItem('id')}/quizzes`} /> : null}
+        {this.state.redirect ? <Redirect to='/rocket/quizzes' /> : null}
       </Modal>
     )
   }

--- a/client/src/components/Modals/SignUpModal.js
+++ b/client/src/components/Modals/SignUpModal.js
@@ -63,7 +63,6 @@ class SignUpModal extends Component {
                   const createdUserData = data.data.createTeacher
                   if (createdUserData) {
                     localStorage.setItem('token', createdUserData.jwtString)
-                    localStorage.setItem('id', createdUserData.teacher.TeacherID)
                     this.setState({
                       name: '',
                       email: '',
@@ -117,7 +116,7 @@ class SignUpModal extends Component {
             </form>
           )}
         </Mutation>
-        {this.state.redirect ? <Redirect to={`/${localStorage.getItem('id')}/quizzes`} /> : null}
+        {this.state.redirect ? <Redirect to='/rocket/quizzes' /> : null}
       </Modal>
     )
   }

--- a/client/src/components/PageError/PageError.js
+++ b/client/src/components/PageError/PageError.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import './PageError.css'
+
+const PageError = () => {
+  return (
+    <div>
+      404 Page Not Found
+    </div>
+  )
+}
+
+export default PageError

--- a/client/src/components/Quizzes/Quizzes.js
+++ b/client/src/components/Quizzes/Quizzes.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import './Quizzes.css'
-// const quizzesTest = require('./quizzesTest.json')
 
 class Quizzes extends Component {
   constructor () {
@@ -8,10 +7,6 @@ class Quizzes extends Component {
     this.state = {
     }
   }
-
-  // componentDidMount () {
-  //   const quizzes = quizzesTest.quizzes
-  // }
 
   render () {
     return (

--- a/client/src/components/RocketList/RocketList.js
+++ b/client/src/components/RocketList/RocketList.js
@@ -3,8 +3,9 @@ import Quizzes from '../Quizzes/Quizzes'
 import Classes from '../Classes/Classes'
 import Billing from '../Billing/Billing'
 import Settings from '../Settings/Settings'
+import PageError from '../PageError/PageError'
 import { Breadcrumb, BreadcrumbItem, Button } from 'reactstrap'
-import { Route, Link, Redirect, withRouter } from 'react-router-dom'
+import { Route, Switch, Link, Redirect, withRouter } from 'react-router-dom'
 import './RocketList.css'
 
 class RocketList extends Component {
@@ -28,25 +29,25 @@ class RocketList extends Component {
     return (
       <div className='rocket_list_container'>
         <span className='username'>Welcome {this.state.username}</span>
-        {window.location.pathname === `/${localStorage.getItem('id')}/quizzes`
+        {window.location.pathname === '/rocket/quizzes'
           ? <Breadcrumb tag='nav' className='nav_bread_crumb'>
             <BreadcrumbItem tag='a' href='/'>Home</BreadcrumbItem>
             <BreadcrumbItem active>Quizzes</BreadcrumbItem>
           </Breadcrumb>
           : null }
-        {window.location.pathname === `/${localStorage.getItem('id')}/classes`
+        {window.location.pathname === '/rocket/classes'
           ? <Breadcrumb tag='nav' className='nav_bread_crumb'>
             <BreadcrumbItem tag='a' href='/'>Home</BreadcrumbItem>
             <BreadcrumbItem active>Classes</BreadcrumbItem>
           </Breadcrumb>
           : null }
-        {window.location.pathname === `/${localStorage.getItem('id')}/billing`
+        {window.location.pathname === '/rocket/billing'
           ? <Breadcrumb tag='nav' className='nav_bread_crumb'>
             <BreadcrumbItem tag='a' href='/'>Home</BreadcrumbItem>
             <BreadcrumbItem active>Billing</BreadcrumbItem>
           </Breadcrumb>
           : null }
-        {window.location.pathname === `/${localStorage.getItem('id')}/settings`
+        {window.location.pathname === '/rocket/settings'
           ? <Breadcrumb tag='nav' className='nav_bread_crumb'>
             <BreadcrumbItem tag='a' href='/'>Home</BreadcrumbItem>
             <BreadcrumbItem active>Settings</BreadcrumbItem>
@@ -54,16 +55,19 @@ class RocketList extends Component {
           : null }
         <div className='rocket_list_main'>
           <div className='rocket_list_navbar'>
-            <Link to={`/${localStorage.getItem('id')}/quizzes`}>Quizzes</Link>
-            <Link to={`/${localStorage.getItem('id')}/classes`}>Classes</Link>
-            <Link to={`/${localStorage.getItem('id')}/billing`}>Billing</Link>
-            <Link to={`/${localStorage.getItem('id')}/settings`}>Settings</Link>
+            <Link to='/rocket/quizzes'>Quizzes</Link>
+            <Link to='/rocket/classes'>Classes</Link>
+            <Link to='/rocket/billing'>Billing</Link>
+            <Link to='/rocket/settings'>Settings</Link>
             <Button color='warning' className='logOut' onClick={this.logOut}>Log Out</Button>
           </div>
-          <Route exact path='/:userId/quizzes' component={Quizzes} />
-          <Route exact path='/:userId/classes' component={Classes} />
-          <Route exact path='/:userId/billing' component={Billing} />
-          <Route exact path='/:userId/settings' component={Settings} />
+          <Switch>
+            <Route exact path='/rocket/quizzes' component={Quizzes} />
+            <Route exact path='/rocket/classes' component={Classes} />
+            <Route exact path='/rocket/billing' component={Billing} />
+            <Route exact path='/rocket/settings' component={Settings} />
+            <Route component={PageError} />
+          </Switch>
         </div>
         {this.state.redirect ? <Redirect to='/' /> : null}
       </div>


### PR DESCRIPTION
# Description

Removed the id from the URI path and added a page error component to display 404 messages when the user traverses to an unknown path for the site. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I tested this on my local machine. When the user logs in or signs up successfully they would be redirect to their rocket list page. Also, the id is no longer stored in local storage and used in the URI. If the user tries to enter a path that is unknown to the site they will a receive a 404 page not found message. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
