### PR TITLE
Brandon/add quiz to classes

### DIFF
--- a/quizzes/graphql/mutation.py
+++ b/quizzes/graphql/mutation.py
@@ -7,6 +7,7 @@ import time
 from decouple import config
 from graphql import GraphQLError
 from quizzes.models import Class, Quiz, Question, Choice, Teacher, Student, Class_Quiz
+from uuid import UUID
 
 
 '''
@@ -273,6 +274,45 @@ class CreateQuizMutation(graphene.ObjectType):
     last_modified = graphene.String()
 '''
 end CreateQuiz
+'''
+
+
+'''
+start AddQuizToClass
+'''
+class AddQuizToClass(graphene.Mutation):
+    class Arguments:
+        QuizID     = graphene.String()
+        Classroom  = graphene.String()
+        encJWT     = graphene.String()
+
+    quiz = graphene.Field(lambda: AddQuizToClassMutation)
+
+    @staticmethod
+    def mutate(self, info, QuizID, Classroom, encJWT):
+        secret     = config('SECRET_KEY')
+        algorithm  = 'HS256'
+        decJWT     = jwt.decode(encJWT, secret, algorithms=[ algorithm ])
+        teacherID  = decJWT[ 'sub' ][ 'id' ]
+        teacher    = Teacher.objects.get(TeacherID=teacherID)
+        classroom  = Class.objects.get(ClassID=Classroom)
+        quiz       = Quiz.objects.get(QuizID=QuizID)
+
+        quiz.Classes.add(classroom)
+        quiz.save()
+
+        return AddQuizToClass(quiz=quiz)
+
+
+class AddQuizToClassMutation(graphene.ObjectType):
+    QuizID        = graphene.String()
+    QuizName      = graphene.String()
+    Teacher       = graphene.String()
+    Public        = graphene.String()
+    created_at    = graphene.String()
+    last_modified = graphene.String()
+'''
+end AddQuizToClass
 '''
 
 

--- a/quizzes/schema.py
+++ b/quizzes/schema.py
@@ -10,7 +10,8 @@ from quizzes.graphql.mutations.classes import CreateClass
 from quizzes.models import Class, Quiz, Question, Choice, Teacher, Student, Student_Quiz, Class_Quiz
 
 from quizzes.graphql.mutation import (
-    CreateTeacher, QueryTeacher, CreateStudent, CreateQuiz, CreateQuestion, CreateChoice, UpdateTeacherInformation
+    CreateTeacher, QueryTeacher, CreateStudent, CreateQuiz, CreateQuestion,
+    CreateChoice, UpdateTeacherInformation, AddQuizToClass
 )
 
 from quizzes.graphql.query import (
@@ -24,14 +25,15 @@ class Mutation(graphene.ObjectType):
     Mutation class allows us to make POST/Mutation requests to create new
     fields
     '''
-    create_class    = CreateClass.Field()
-    create_teacher  = CreateTeacher.Field()
-    update_teacher  = UpdateTeacherInformation.Field()
-    query_teacher   = QueryTeacher.Field()
-    create_student  = CreateStudent.Field()
-    create_quiz     = CreateQuiz.Field()
-    create_question = CreateQuestion.Field()
-    create_choice   = CreateChoice.Field()
+    create_class      = CreateClass.Field()
+    create_teacher    = CreateTeacher.Field()
+    update_teacher    = UpdateTeacherInformation.Field()
+    query_teacher     = QueryTeacher.Field()
+    create_student    = CreateStudent.Field()
+    create_quiz       = CreateQuiz.Field()
+    create_question   = CreateQuestion.Field()
+    create_choice     = CreateChoice.Field()
+    add_quiz_to_class = AddQuizToClass.Field()
 
 
 class Query(graphene.ObjectType):


### PR DESCRIPTION
# Description

Allows users to reuse the same `Quiz` in multiple `Class`rooms with new mutation `addQuizToClass`

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Navigate to `localhost:8000/graphiql`
- Create: `Teacher`, `Class` (create two), `Quiz`, `Question`, `Choice`
- Add a quiz to a different `Class` using the new `addQuizToClass` mutation
- Make a query for a teacher and display all of their `Class`rooms.
- Should display two `Class`rooms each with the same `Quiz`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
