### PR TITLE
All logout methods now also call `clearStore()` on the Apollo client

### DIFF
--- a/client/src/components/NavBar/NavBar.js
+++ b/client/src/components/NavBar/NavBar.js
@@ -4,6 +4,7 @@ import NavContainerLeft from './NavContainerLeft'
 import NavContainerRight from './NavContainerRight'
 import LogInModal from '../Modals/LogInModal'
 import SignUpModal from '../Modals/SignUpModal'
+import { client } from '../../index'
 import './NavBar.css'
 
 class NavBar extends Component {
@@ -29,6 +30,7 @@ class NavBar extends Component {
   }
 
   logOut = () => {
+    client.clearStore()
     localStorage.clear()
     this.forceUpdate()
     this.setState({

--- a/client/src/components/RocketList/RocketList.js
+++ b/client/src/components/RocketList/RocketList.js
@@ -9,6 +9,7 @@ import EditClass from '../Classes/EditClass'
 import { Breadcrumb, BreadcrumbItem, Button } from 'reactstrap'
 import { Route, Switch, Link, Redirect, withRouter } from 'react-router-dom'
 import gql from 'graphql-tag'
+import { client } from '../../index'
 import { Query } from 'react-apollo'
 import './RocketList.css'
 
@@ -28,6 +29,7 @@ class RocketList extends Component {
   }
 
   logOut = () => {
+    client.clearStore()
     localStorage.clear()
     this.forceUpdate()
     this.setState({

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -10,7 +10,7 @@ import ApolloClient from 'apollo-boost'
 
 const apiURI = process.env.NODE_ENV !== 'production' ? 'http://localhost:8000/graphiql/' : '/graphiql/'
 
-const client = new ApolloClient({
+export const client = new ApolloClient({
   uri: apiURI
 })
 


### PR DESCRIPTION
# Description

Logging out from either the initial navbar or the main menu ("rocket list") will now call `clearStore()` on the Apollo client. This should prevent any stored queries or results from being accessible to later users.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Set up console logs on the `render` method of either the navbar or the rocket list to output `client.store` and then one in the `logOut` method to output the same. When the component loads, in your browsers dev console you should see `DataStore {cache: InMemoryCache}` - expand this, expand `cache`, expand `data`, and within data you should see numerous queries present. Click the `logout` button and then expand the new `DataStore` in the console: the data cache should be devoid of any queries.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
