### PR TITLE
Abbott/segments error fix

### DIFF
--- a/client/src/components/Modals/LogInModal.js
+++ b/client/src/components/Modals/LogInModal.js
@@ -46,7 +46,7 @@ class LogInModal extends Component {
             <div>
               <form onSubmit={event => {
                 event.preventDefault()
-                const login = loginUser({ variables: { TeacherEmail: email, TeacherPW: password } })
+                const login = loginUser({ variables: { TeacherEmail: email, TeacherPW: password }, refetchQueries: ['GetCurrentInformation'] })
                 login.then(data => {
                   const logInData = data.data.queryTeacher
                   if (logInData) {

--- a/client/src/components/Modals/SignUpModal.js
+++ b/client/src/components/Modals/SignUpModal.js
@@ -58,7 +58,7 @@ class SignUpModal extends Component {
               if (this.state.password !== this.state.confirmPassword) {
                 this.setState({ passwordError: 'Passwords do not match.' })
               } else {
-                const createdUser = createNewUser({ variables: { TeacherName: name, TeacherEmail: email, TeacherPW: password } })
+                const createdUser = createNewUser({ variables: { TeacherName: name, TeacherEmail: email, TeacherPW: password }, refetchQueries: ['GetCurrentInformation'] })
                 createdUser.then(data => {
                   const createdUserData = data.data.createTeacher
                   if (createdUserData) {

--- a/client/src/components/Quizzes/Quizzes.js
+++ b/client/src/components/Quizzes/Quizzes.js
@@ -10,9 +10,9 @@ import QuizList from './QuizList'
 
 import './Quizzes.css'
 
-const getCurrentInformation = gql`
- {
-    teacher(encJwt: "${localStorage.getItem('token')}") {
+const GET_CURRENT_INFORMATION = gql`
+ query GetCurrentInformation($encJwt: String!) {
+    teacher(encJwt: $encJwt) {
       quizSet {
         QuizID
         QuizName
@@ -69,12 +69,12 @@ class Quizzes extends Component {
       <div className='quizzes_container'>
         <span>Add a new Quiz</span>
 
-        <Query query={getCurrentInformation}>
+        <Query query={GET_CURRENT_INFORMATION} variables={{ encJwt: localStorage.getItem('token') }}>
           {({ loading, error, data }) => {
             if (loading) return 'Loading...'
             if (error) return `Error: ${error.message}`
 
-            if (data) {
+            if (data && data.teacher[0]) {
               return this.renderQuizComponent(data)
             }
           }}

--- a/client/src/components/Settings/Settings.js
+++ b/client/src/components/Settings/Settings.js
@@ -26,11 +26,9 @@ class Settings extends Component {
       oldPassword: null,
       newPassword: ''
     }
-
-    this.handleInputChange = this.handleInputChange.bind(this)
   }
 
-  handleInputChange (event) {
+  handleInputChange = (event) => {
     this.setState({ [event.target.name]: event.target.value })
   }
 

--- a/client/src/components/Settings/Settings.js
+++ b/client/src/components/Settings/Settings.js
@@ -7,8 +7,8 @@ import './Settings.css'
 
 // GraphQL Mutation to update user information
 const updateInformation = gql`
-  mutation UpdateTeacher($TeacherName: String, $TeacherEmail: String, $OldPassword: String!, $NewPassword: String) {
-    updateTeacher(incomingJwt: "${window.localStorage.getItem('token')}", TeacherName: $TeacherName, TeacherEmail: $TeacherEmail, OldPassword: $OldPassword, NewPassword: $NewPassword) {
+  mutation UpdateTeacher($incomingJwt: String!, $TeacherName: String, $TeacherEmail: String, $OldPassword: String!, $NewPassword: String) {
+    updateTeacher(incomingJwt: $incomingJwt, TeacherName: $TeacherName, TeacherEmail: $TeacherEmail, OldPassword: $OldPassword, NewPassword: $NewPassword) {
       teacher {
         TeacherName
         TeacherEmail
@@ -44,8 +44,9 @@ class Settings extends Component {
               <form onSubmit={event => {
                 event.preventDefault()
                 const updatedInfo = updateTeacher({
-                  variables:
-                  { TeacherName: name,
+                  variables: {
+                    incomingJwt: localStorage.getItem('token'),
+                    TeacherName: name,
                     TeacherEmail: email,
                     OldPassword: oldPassword,
                     NewPassword: newPassword


### PR DESCRIPTION
# Description

This should fix all the "not enough segments" errors that pop up after logging into a new account. I believe it's because many of the GraphQL query strings were attempting to insert the JWT from local storage directly, rather than pass them into the query through GQL variables.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Since updating these GQL strings I haven't encountered any segment errors even with multiple signouts and signins, though the only way we'll know for real is to test it in prod.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
