### PR TITLE
Fixes user information update password bug

### DIFF
--- a/quizzes/graphql/mutation.py
+++ b/quizzes/graphql/mutation.py
@@ -91,13 +91,17 @@ class UpdateTeacherInformation(graphene.Mutation):
         if old_pw:
             if teacher:
                 if bcrypt.checkpw(old_pw, hashed_old_pw):
-                    new_password = NewPassword.encode('utf-8')
-                    hashed_new_pw = bcrypt.hashpw(new_password, bcrypt.gensalt()).decode('utf-8')
-
-                    # object.save() cannot take any args, so just change entries first
+                    # object.save() cannot take any args, so just change entries directly first.
                     teacher.TeacherName = TeacherName if len(TeacherName) > 0 else teacher.TeacherName
                     teacher.TeacherEmail = TeacherEmail if len(TeacherEmail) > 0 else teacher.TeacherEmail
-                    teacher.TeacherPW = hashed_new_pw if len(hashed_new_pw) > 0 else hashed_old_pw
+
+                    # No point in doing any new password hashing if there's no new password present...
+                    if len(NewPassword) > 0:
+                        new_password = NewPassword.encode('utf-8')
+                        hashed_new_pw = bcrypt.hashpw(new_password, bcrypt.gensalt()).decode('utf-8')
+                        teacher.TeacherPW = hashed_new_pw
+                    
+                    # Save the new teacher data back into the database
                     teacher.save()
 
                     # create DATA for new JWT to replace old one now that we maybe changed name or email


### PR DESCRIPTION
# Description

Previously, if updating user information (username or email) and then providing the old password for verification but NOT adding a new password to the account, a new and corrupted password would still overwrite your current password, which could no longer be changed, and made the account inaccessible.

This behavior should no longer occur.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Testing the BUGGY BEHAVIOR (attempt test in `master`):
- Create a new account, or log into an existing one, and navigate to the Settings page.
- From here, update either (or both) your username and email, and input your current password into the "Old Password" field. Make no changes to the "New Password" field, and save your changes.
- Now attempt to update your user information with anything new, or log out and attempt to log back in: you should receive "Incorrect password" errors.

## Testing the FIX BEHAVIOR (testing this branch):
- Do the same as in the buggy behavior test (make sure to use a new account, your old account is no longer recoverable without some serious work), however you should no longer encounter any problems with updating your user information without also updating your password.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
