### PR TITLE
Brandon/typo fix

### DIFF
--- a/client/src/components/Classes/CreateEditComponents/QuizSelector.js
+++ b/client/src/components/Classes/CreateEditComponents/QuizSelector.js
@@ -19,7 +19,7 @@ class QuizSelector extends Component {
     return (
       <div>
         <QuizSelectModal classID={classID} isOpen={this.state.isOpen} toggle={this.toggle} />
-        <Button onClick={this.toggle}>Add Class</Button>
+        <Button onClick={this.toggle}>Add Quiz</Button>
       </div>
     )
   }

--- a/psql.sh
+++ b/psql.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-psql -h ec2-50-17-206-214.compute-1.amazonaws.com -p 5432 -U smyljtdcjapdhk -W d5u4qm6qtmvqhc


### PR DESCRIPTION
# Description

This PR fixes a typo with the `Add Quiz` button when editing a specific class. It should used to say `Add Class` and now says `Add Quiz`

I've also removed a file, `psql.sh` that contained sensitive information about our production database.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Edit a class and scroll to the bottom. Button should now say `Add Quiz`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
