### PR TITLE
When JWT present, redirect to quizzes instead of allowing landing page

### DIFF
--- a/client/src/components/Landing/Landing.js
+++ b/client/src/components/Landing/Landing.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import NavBar from '../NavBar/NavBar'
 import FirstSection from './FirstSection'
 import Footer from './Footer'
+import { Redirect } from 'react-router-dom'
 import './Landing.css'
 
 import { landingContainer } from './style/style'
@@ -13,6 +14,7 @@ class Landing extends Component {
         <NavBar />
         <FirstSection />
         <Footer />
+        {window.localStorage.getItem('token') ? <Redirect to={'/rocket/'} /> : null}
       </div>
     )
   }

--- a/quizzes/helpers/jwt_helpers.py
+++ b/quizzes/helpers/jwt_helpers.py
@@ -16,7 +16,7 @@ def create_jwt(teacher_id, teacher_name, teacher_email):
         'email': teacher_email
     },
     'iat': time.time(),
-    'exp': time.time() + 86400
+    'exp': time.time() + 2592000 # 30 day expiration time
   }
 
   new_jwt = jwt.encode(payload, key, algorithm=algorithm)


### PR DESCRIPTION
# Description

Prevents users with a JWT token in local storage from reaching the landing page, also increased JWT expiration time to 30 days.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Log in and try to reach the landing page, which should no longer be possible. Logging out will allow visiting this page once again (where you can log in or create a new user).

Testing the 30 day limit on JWT's would require waiting 30 days, so probably don't worry about it for now.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
